### PR TITLE
uvk5_egzumer.py: fix upload calibration

### DIFF
--- a/chirp/drivers/uvk5_egzumer.py
+++ b/chirp/drivers/uvk5_egzumer.py
@@ -869,19 +869,24 @@ class UVK5RadioEgzumer(uvk5.UVK5RadioBase):
                 _mem[elname] = val
 
             if elname == "key1_shortpress_action":
-                _mem.key1_shortpress_action = element.value
+                _mem.key1_shortpress_action = \
+                    KEYACTIONS_LIST.index(element.value)
 
             elif elname == "key1_longpress_action":
-                _mem.key1_longpress_action = element.value
+                _mem.key1_longpress_action = \
+                    KEYACTIONS_LIST.index(element.value)
 
             elif elname == "key2_shortpress_action":
-                _mem.key2_shortpress_action = element.value
+                _mem.key2_shortpress_action = \
+                    KEYACTIONS_LIST.index(element.value)
 
             elif elname == "key2_longpress_action":
-                _mem.key2_longpress_action = element.value
+                _mem.key2_longpress_action = \
+                    KEYACTIONS_LIST.index(element.value)
 
             elif elname == "keyM_longpress_action":
-                _mem.keyM_longpress_action = element.value
+                _mem.keyM_longpress_action = \
+                    KEYACTIONS_LIST.index(element.value)
 
             elif element.changed() and elname.startswith("cal."):
                 _mem.get_path(elname).set_value(element.value)

--- a/chirp/drivers/uvk5_egzumer.py
+++ b/chirp/drivers/uvk5_egzumer.py
@@ -458,7 +458,7 @@ class UVK5RadioEgzumer(uvk5.UVK5RadioBase):
     _steps = [2.5, 5, 6.25, 10, 12.5, 25, 8.33, 0.01, 0.05, 0.1, 0.25, 0.5, 1,
               1.25, 9, 15, 20, 30, 50, 100, 125, 200, 250, 500]
 
-    upload_calibration = False
+    _upload_calibration = False
 
     @classmethod
     def k5_approve_firmware(cls, firmware):
@@ -1454,7 +1454,7 @@ class UVK5RadioEgzumer(uvk5.UVK5RadioBase):
 
         val = RadioSettingValueBoolean(False)
 
-        radio_setting = RadioSetting("upload_calibration",
+        radio_setting = RadioSetting("_upload_calibration",
                                      "Upload calibration", val)
         radio_setting.set_warning(
             _('This option may break your radio! '


### PR DESCRIPTION
The do_upload function in uvk5.py expects a variable with an underscore preffix
